### PR TITLE
Maintain passed CLI arguments

### DIFF
--- a/ap.sh
+++ b/ap.sh
@@ -1,1 +1,4 @@
-ansible-playbook ./deploy.yml
+#!/bin/zsh
+
+# shellcheck disable=SC2068
+ansible-playbook ./deploy.yml $@


### PR DESCRIPTION
This is particularly useful for just adding on optional ansible-playbook CLI arguments.
For example:

> ./ap.sh -vvv

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>